### PR TITLE
OAuth 카카오톡 1차 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.1",
+        "passport-kakao": "^1.0.1",
         "passport-naver-v2": "^2.0.8",
         "pg": "^8.16.0",
         "reflect-metadata": "^0.2.2",
@@ -11810,6 +11811,35 @@
         "passport-strategy": "^1.0.0"
       }
     },
+    "node_modules/passport-kakao": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/passport-kakao/-/passport-kakao-1.0.1.tgz",
+      "integrity": "sha512-uItaYRVrTHL6iGPMnMZvPa/O1GrAdh/V6EMjOHcFlQcVroZ9wgG7BZ5PonMNJCxfHQ3L2QVNRnzhKWUzSsumbw==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth2": "~1.1.2",
+        "pkginfo": "~0.3.0"
+      }
+    },
+    "node_modules/passport-kakao/node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
+    },
+    "node_modules/passport-kakao/node_modules/passport-oauth2": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.1.2.tgz",
+      "integrity": "sha512-wpsGtJDHHQUjyc9WcV9FFB0bphFExpmKtzkQrxpH1vnSr6RcWa3ZEGHx/zGKAh2PN7Po9TKYB1fJeOiIBspNPA==",
+      "dependencies": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/passport-naver-v2": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/passport-naver-v2/-/passport-naver-v2-2.0.8.tgz",
@@ -12150,6 +12180,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkginfo": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+      "integrity": "sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.1",
+    "passport-kakao": "^1.0.1",
     "passport-naver-v2": "^2.0.8",
     "pg": "^8.16.0",
     "reflect-metadata": "^0.2.2",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -49,23 +49,56 @@ export class AuthController {
   })
   @ApiOkResponse({
     description: "성공 시 응답 데이터",
-    example: {
-      success: true,
-      data: {
-        id: "1be1a0c8-2e45-4a45-981f-f5b756dee42c",
-        username: "동혁",
-        email: "hyuk.development@gmail.com",
-        isProfile: null,
-        authType: null,
-        provider: "google",
-        phoneNumber: "000-0000-0000",
-        profileImage:
-          "https://lh3.googleusercontent.com/a/ACg8ocIDnlUuGZT05pI-d9KsJO5_6ouGlbFgej4zTT1Fqh5ai_Lclrw=s96-c",
-        wantService: null,
-        livingPlace: null,
-        createdAt: "2025-05-22T02:33:41.240Z",
+    examples: {
+      customerLoginSuccess: {
+        summary: "손님 로그인 성공",
+        value: {
+          success: true,
+          data: {
+            id: "1be1a0c8-2e45-4a45-981f-f5b756dee42c",
+            username: "동혁",
+            email: "hyuk.development@gmail.com",
+            isProfile: null,
+            authType: null,
+            provider: "google",
+            phoneNumber: "000-0000-0000",
+            profileImage:
+              "https://lh3.googleusercontent.com/a/ACg8ocIDnlUuGZT05pI-d9KsJO5_6ouGlbFgej4zTT1Fqh5ai_Lclrw=s96-c",
+            wantService: null,
+            livingPlace: null,
+            createdAt: "2025-05-22T02:33:41.240Z",
+          },
+          message: "손님 로그인 완료",
+        },
       },
-      message: "로그인 완료",
+      moverLoginSuccess: {
+        summary: "기사 로그인 성공",
+        value: {
+          success: true,
+          data: {
+            id: "93f6c859-c606-4213-93a7-0fa3ff59fcc6",
+            username: "동혁",
+            nickname: null,
+            isProfile: null,
+            email: "hyuk.development@gmail.com",
+            phoneNumber: "000-0000-0000",
+            provider: "google",
+            profileImage:
+              "https://lh3.googleusercontent.com/a/ACg8ocIDnlUuGZT05pI-d9KsJO5_6ouGlbFgej4zTT1Fqh5ai_Lclrw=s96-c",
+            img: null,
+            serviceArea: null,
+            serviceList: null,
+            intro: null,
+            career: null,
+            detailDescription: null,
+            likeCount: 0,
+            totalRating: 0,
+            reviewCounts: 0,
+            createdAt: "2025-05-22T05:48:57.417Z",
+          },
+          message: "기사 로그인 완료",
+        },
+      },
     },
   })
   @ApiResponse({
@@ -119,7 +152,17 @@ export class AuthController {
         livingPlace: null,
         createdAt: "2025-05-23T06:17:20.566Z",
       },
-      message: "로그인 완료",
+      message: "손님 로그인 완료",
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: "잘못된 역할 정보일 때",
+    example: {
+      success: false,
+      data: null,
+      message: "존재하지 않는 역할 정보입니다.",
+      errorCode: "UnauthorizedException",
     },
   })
   async setRoleAndRedirectNaver(
@@ -142,6 +185,61 @@ export class AuthController {
     return res.redirect(redirectUrl);
   }
 
+  @Get("kakao/:role/login")
+  @ApiOperation({
+    summary: "카카오 OAuth 로그인",
+    description: "카카오 OAuth를 사용한 로그인을 진행합니다.",
+  })
+  @ApiOkResponse({
+    description: "성공 시 응답 데이터",
+    example: {
+      success: true,
+      data: {
+        id: "af8d1f50-8cff-4627-bb7e-6acdd2203d7c",
+        username: "이동혁",
+        email: "kakao@test.email",
+        isProfile: false,
+        authType: null,
+        provider: "kakao",
+        phoneNumber: "000-0000-0000",
+        profileImage:
+          "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg",
+        wantService: null,
+        livingPlace: null,
+        createdAt: "2025-05-26T02:27:06.202Z",
+        updatedAt: "2025-05-26T02:27:06.202Z",
+      },
+      message: "손님 로그인 완료",
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: "잘못된 역할 정보일 때",
+    example: {
+      success: false,
+      data: null,
+      message: "존재하지 않는 역할 정보입니다.",
+      errorCode: "UnauthorizedException",
+    },
+  })
+  async setRoleAndRedirectKakao(
+    @Param("role") role: string,
+    @Res() res: Response,
+  ) {
+    const state = encodeURIComponent(JSON.stringify({ role }));
+    const clientId = this.configService.get<string>("KAKAO_CLIENT_ID");
+    const redirectUri = this.configService.get<string>("KAKAO_REDIRECT_URI");
+
+    const redirectUrl =
+      "https://kauth.kakao.com/oauth/authorize" +
+      `?client_id=${clientId}` +
+      `&redirect_uri=${redirectUri}` +
+      `&response_type=code` +
+      `&state=${state}`;
+
+    return res.redirect(redirectUrl);
+  }
+
   @Get("google/redirect")
   @UseGuards(AuthGuard("google"))
   @ApiOperation({
@@ -158,7 +256,26 @@ export class AuthController {
 
   @Get("naver/redirect")
   @UseGuards(AuthGuard("naver"))
+  @ApiOperation({
+    summary: "네이버 로그인 성공 시 리다이렉트 (직접 연결 x)",
+    description:
+      "네이버 로그인을 성공했을 때 자동으로 리다이렉트하여 실행되는 api",
+  })
   async naverRedirect(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    return this.handleOauthRedirect(req, res);
+  }
+
+  @Get("kakao/redirect")
+  @UseGuards(AuthGuard("kakao"))
+  @ApiOperation({
+    summary: "카카오 로그인 성공 시 리다이렉트 (직접 연결 x)",
+    description:
+      "카카오 로그인을 성공했을 때 자동으로 리다이렉트하여 실행되는 api",
+  })
+  async kakaoRedirect(
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
@@ -179,7 +296,7 @@ export class AuthController {
         req.user,
       );
       SetAuthCookies.set(res, userInfo.accessToken, userInfo.refreshToken);
-      return CommonApiResponse.success(userInfo.customer, "로그인 완료");
+      return CommonApiResponse.success(userInfo.customer, "손님 로그인 완료");
     }
 
     if (req.user?.role === "mover") {
@@ -187,7 +304,7 @@ export class AuthController {
         req.user,
       );
       SetAuthCookies.set(res, userInfo.accessToken, userInfo.refreshToken);
-      return CommonApiResponse.success(userInfo.mover, "로그인 완료");
+      return CommonApiResponse.success(userInfo.mover, "기사 로그인 완료");
     }
 
     throw new BadRequestException();

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -136,23 +136,57 @@ export class AuthController {
   })
   @ApiOkResponse({
     description: "성공 시 응답 데이터",
-    example: {
-      success: true,
-      data: {
-        id: "3392fd0f-0c69-47d6-bcc4-61b0eb5a663a",
-        username: null,
-        email: "lnetwork@naver.com",
-        isProfile: false,
-        authType: null,
-        provider: "naver",
-        phoneNumber: "000-0000-0000",
-        profileImage:
-          "https://ssl.pstatic.net/static/pwe/address/img_profile.png",
-        wantService: null,
-        livingPlace: null,
-        createdAt: "2025-05-23T06:17:20.566Z",
+    examples: {
+      customerLoginSuccess: {
+        summary: "손님 로그인 성공",
+        value: {
+          success: true,
+          data: {
+            id: "098775a4-101c-482f-bd13-4a0ccb73f869",
+            username: "이동혁",
+            email: "lnetwork@naver.com",
+            isProfile: false,
+            authType: null,
+            provider: "naver",
+            phoneNumber: "000-0000-0000",
+            profileImage:
+              "https://ssl.pstatic.net/static/pwe/address/img_profile.png",
+            wantService: null,
+            livingPlace: null,
+            createdAt: "2025-05-23T07:27:05.972Z",
+            updatedAt: "2025-05-26T02:16:52.823Z",
+          },
+          message: "손님 로그인 완료",
+        },
       },
-      message: "손님 로그인 완료",
+      moverLoginSuccess: {
+        summary: "기사 로그인 성공",
+        value: {
+          success: true,
+          data: {
+            id: "dbfbe32a-3c98-432c-9622-3f48c50ca905",
+            username: "이동혁",
+            nickname: null,
+            isProfile: false,
+            email: "lnetwork@naver.com",
+            phoneNumber: "000-0000-0000",
+            provider: "naver",
+            profileImage:
+              "https://ssl.pstatic.net/static/pwe/address/img_profile.png",
+            img: null,
+            serviceArea: null,
+            serviceList: null,
+            intro: null,
+            career: null,
+            detailDescription: null,
+            likeCount: 0,
+            totalRating: 0,
+            reviewCounts: 0,
+            createdAt: "2025-05-23T07:39:58.238Z",
+          },
+          message: "기사 로그인 완료",
+        },
+      },
     },
   })
   @ApiResponse({
@@ -192,24 +226,57 @@ export class AuthController {
   })
   @ApiOkResponse({
     description: "성공 시 응답 데이터",
-    example: {
-      success: true,
-      data: {
-        id: "af8d1f50-8cff-4627-bb7e-6acdd2203d7c",
-        username: "이동혁",
-        email: "kakao@test.email",
-        isProfile: false,
-        authType: null,
-        provider: "kakao",
-        phoneNumber: "000-0000-0000",
-        profileImage:
-          "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg",
-        wantService: null,
-        livingPlace: null,
-        createdAt: "2025-05-26T02:27:06.202Z",
-        updatedAt: "2025-05-26T02:27:06.202Z",
+    examples: {
+      customerLoginSuccess: {
+        summary: "손님 로그인 성공",
+        value: {
+          success: true,
+          data: {
+            id: "af8d1f50-8cff-4627-bb7e-6acdd2203d7c",
+            username: "이동혁",
+            email: "kakao@test.email",
+            isProfile: false,
+            authType: null,
+            provider: "kakao",
+            phoneNumber: "000-0000-0000",
+            profileImage:
+              "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg",
+            wantService: null,
+            livingPlace: null,
+            createdAt: "2025-05-26T02:27:06.202Z",
+            updatedAt: "2025-05-26T02:27:06.202Z",
+          },
+          message: "손님 로그인 완료",
+        },
       },
-      message: "손님 로그인 완료",
+      moverLoginSuccess: {
+        summary: "기사 로그인 성공",
+        value: {
+          success: true,
+          data: {
+            id: "693e520a-95ef-410f-add7-f7734ace85fa",
+            username: "이동혁",
+            nickname: null,
+            isProfile: false,
+            email: "kakao@test.email",
+            phoneNumber: "000-0000-0000",
+            provider: "kakao",
+            profileImage:
+              "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg",
+            img: null,
+            serviceArea: null,
+            serviceList: null,
+            intro: null,
+            career: null,
+            detailDescription: null,
+            likeCount: 0,
+            totalRating: 0,
+            reviewCounts: 0,
+            createdAt: "2025-05-26T04:16:13.817Z",
+          },
+          message: "기사 로그인 완료",
+        },
+      },
     },
   })
   @ApiResponse({

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -358,6 +358,8 @@ export class AuthController {
       | CustomerGoogleOauthLoginResponseDto
       | MoverGoogleOauthLoginResponseDto;
 
+    console.log(req.user)
+
     if (req.user?.role === "customer") {
       userInfo = await this.customerAuthService.signUpOrSignInByOauthCustomer(
         req.user,

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -14,6 +14,7 @@ import { Customer } from "../customer/customer.entity";
 import { Mover } from "../mover/mover.entity";
 import { MoverAuthService } from "src/mover/auth/auth.service";
 import { NaverStrategy } from "./strategies/naver.strategy";
+import { KakaoStrategy } from "./strategies/kakao.strategy";
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { NaverStrategy } from "./strategies/naver.strategy";
     AuthService,
     GoogleStrategy,
     NaverStrategy,
+    KakaoStrategy,
     JwtStrategy,
     CustomerAuthService,
     MoverAuthService,

--- a/src/auth/strategies/kakao.strategy.ts
+++ b/src/auth/strategies/kakao.strategy.ts
@@ -1,0 +1,55 @@
+import { Injectable, UnauthorizedException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { PassportStrategy } from "@nestjs/passport";
+import { Request } from "express";
+import { Strategy as KakaoOAuthStrategy } from "passport-kakao";
+
+@Injectable()
+export class KakaoStrategy extends PassportStrategy(
+  KakaoOAuthStrategy,
+  "kakao",
+) {
+  constructor(private configService: ConfigService) {
+    super({
+      clientID: configService.get<string>("KAKAO_CLIENT_ID"),
+      callbackURL: configService.get<string>("KAKAO_REDIRECT_URI"),
+      clientSecret: configService.get<string>("KAKAO_REDIRECT_URI"),
+      passReqToCallback: true,
+    });
+  }
+
+  async validate(
+    req: Request,
+    accessToken: string,
+    refreshToken: string,
+    profile: any,
+    done: Function,
+  ): Promise<any> {
+    const state = req.query.state;
+
+    if (typeof state !== "string") {
+      throw new UnauthorizedException("역할 정보가 올바르지 않습니다.");
+    }
+
+    const decoded = decodeURIComponent(state);
+    const parsed = JSON.parse(decoded);
+    const role = parsed.role;
+
+    if (role !== "customer" && role !== "mover") {
+      throw new UnauthorizedException("존재하지 않는 역할 정보입니다.");
+    }
+
+    const kakaoAccount = profile._json.kakao_account;
+
+    const user = {
+      provider: "kakao",
+      email: "kakao@test.email",
+      name: kakaoAccount.profile?.nickname,
+      photo:
+        "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg",
+      role,
+    };
+
+    done(null, user);
+  }
+}

--- a/src/auth/strategies/kakao.strategy.ts
+++ b/src/auth/strategies/kakao.strategy.ts
@@ -43,7 +43,7 @@ export class KakaoStrategy extends PassportStrategy(
 
     const user = {
       provider: "kakao",
-      email: "kakao@test.email",
+      email: profile.id + "@test.email",
       name: kakaoAccount.profile?.nickname,
       photo:
         "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg",

--- a/src/customer/auth/auth.service.ts
+++ b/src/customer/auth/auth.service.ts
@@ -88,6 +88,7 @@ export class CustomerAuthService {
       userId: newCustomer.id,
       accessToken,
       refreshToken,
+      provider: newCustomer.provider,
     });
 
     return { refreshToken, accessToken, customer: newCustomerWithoutPw };


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)

- 카카오톡 OAuth 로그인 구현

## 📢 팀원들에게 공유 사항

- 이메일 주소는 사업자 등록을 해야 가지고 올 수 있어서 일단 1239823@test.email로 카카오톡 고유 id + @test.email 형식으로 고유 값 가지게 했습니다.
- 환경변수 설정 노션에 업데이트 했습니다.
