### PR TITLE
OAuth 리다이렉트 프론트 기준으로 수정

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -318,7 +318,8 @@ export class AuthController {
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
-    return this.handleOauthRedirect(req, res);
+    await this.handleOauthRedirect(req, res);
+    return res.redirect(`${this.configService.get('FRONT_URL') ?? "http://localhost:3000"}/oauth/callback`);
   }
 
   @Get("naver/redirect")
@@ -332,7 +333,8 @@ export class AuthController {
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
-    return this.handleOauthRedirect(req, res);
+    await this.handleOauthRedirect(req, res);
+    return res.redirect(`${this.configService.get('FRONT_URL') ?? "http://localhost:3000"}/oauth/callback`);
   }
 
   @Get("kakao/redirect")
@@ -346,7 +348,8 @@ export class AuthController {
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
-    return this.handleOauthRedirect(req, res);
+    await this.handleOauthRedirect(req, res);
+    return res.redirect(`${this.configService.get('FRONT_URL') ?? "http://localhost:3000"}/oauth/callback`);
   }
 
   //OauthRedirect 공통 로직 분리


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)

- 인증 완료 후 프론트 주소로 이동

## 📢 팀원들에게 공유 사항

- http://localhost:3000/oauth/callback (로컬 기준) 으로 이동하도록 설정하였습니다.
- FRONT_URL (백엔드 환경변수) 기준으로 주소가 잡히도록 하였습니다.

