### PR TITLE
FIX: JwtGuard 사용하는 컨트롤러에서 req.user.userType 조회 가능하도록 수정

### DIFF
--- a/src/common/guards/jwt-cookie-auth.guard.ts
+++ b/src/common/guards/jwt-cookie-auth.guard.ts
@@ -23,7 +23,7 @@ export class JwtCookieAuthGuard implements CanActivate {
       if (!user) {
         throw new UnauthorizedException("존재하지않는 AccessToken입니다.");
       }
-      request.user = { userId: user.userId };
+      request.user = { userId: user.userId, userType: user.userType };
       return true;
     } catch (error) {
       throw new UnauthorizedException("Invalid or expired access token.");


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)

- JwtGuard 사용하는 컨트롤러에서 req.user.userType 조회 가능하도록 수정

## 📢 팀원들에게 공유 사항

- @UseGuards(JwtCookieAuthGuard) 사용하는 곳에서 req.user.userType을 통해 유저가 손님인지, 기사인지 조회 가능합니다.