### PR TITLE
기사 엔티티 수정, assignMover 엔티티 수정

### DIFF
--- a/src/mover/mover.entity.ts
+++ b/src/mover/mover.entity.ts
@@ -57,7 +57,7 @@ export class Mover {
   @Column({ default: 0 })
   likeCount: number;
 
-  @Column({ default: 0 })
+  @Column({ type: "float", default: 0 })
   totalRating: number; // 별점 총점
 
   @Column({ default: 0 })

--- a/src/quotation/entities/assign-mover.entity.ts
+++ b/src/quotation/entities/assign-mover.entity.ts
@@ -15,7 +15,7 @@ export class AssignMover {
   @Column()
   status: AssignStatusKey;
 
-  @Column({ nullable: true })
+  @Column({ type: "text", nullable: true })
   rejectedReason: string | null;
 
   // tb-Mover


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)

- 별점 평균값을 담는 totalRating이 정수로만 담을 수 있게 되어있어서 소수도 담을 수 있도록 수정.
- assign-mover 엔티티에서 rejectReason의 타입이 객체로 되어 있어서 오류 발생하여 해당 부분 수정
