### PR TITLE
refactor(oauth): remove user object from login response to reduce mem…

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -358,8 +358,6 @@ export class AuthController {
   > {
     let userInfo: CustomerOauthLoginResponseDto | MoverOauthLoginResponseDto;
 
-    console.log(req.user);
-
     if (req.user?.role === "customer") {
       userInfo = await this.customerAuthService.signUpOrSignInByOauthCustomer(
         req.user,

--- a/src/common/dto/oauthLogin.dto.ts
+++ b/src/common/dto/oauthLogin.dto.ts
@@ -1,8 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { Type } from "class-transformer";
-import { IsOptional, IsString, ValidateNested } from "class-validator";
-import { SafeCustomer } from "src/customer/types/customerWithoutPw";
-import { SafeMover } from "src/customer/types/moverWithoutPw";
+import { IsOptional, IsString } from "class-validator";
 
 export class OauthLoginRequestDto {
   @IsString()
@@ -39,9 +36,6 @@ export class MoverOauthLoginResponseDto {
   @ApiProperty({ example: "ACCESS_TOKEN", description: "엑세스 토큰" })
   accessToken: string;
 
-  @ApiProperty({ description: "기사 객체 (비밀번호 제외)" })
-  mover: SafeMover;
-
   type: "mover";
 }
 
@@ -53,9 +47,6 @@ export class CustomerOauthLoginResponseDto {
   @IsString()
   @ApiProperty({ example: "ACCESS_TOKEN", description: "엑세스 토큰" })
   accessToken: string;
-
-  @ApiProperty({ description: "손님 객체 (비밀번호 제외)" })
-  customer: SafeCustomer;
 
   type: "customer";
 }

--- a/src/customer/auth/auth.service.ts
+++ b/src/customer/auth/auth.service.ts
@@ -67,7 +67,6 @@ export class CustomerAuthService {
       return {
         refreshToken,
         accessToken,
-        customer: existedCustomerWithoutPw,
         type: "customer",
       };
     }
@@ -102,7 +101,6 @@ export class CustomerAuthService {
     return {
       refreshToken,
       accessToken,
-      customer: newCustomerWithoutPw,
       type: "customer",
     };
   }

--- a/src/customer/types/customerWithoutPw.ts
+++ b/src/customer/types/customerWithoutPw.ts
@@ -1,3 +1,0 @@
-import { Customer } from "../customer.entity";
-
-export type SafeCustomer = Omit<Customer, "password">;

--- a/src/customer/types/moverWithoutPw.ts
+++ b/src/customer/types/moverWithoutPw.ts
@@ -1,3 +1,0 @@
-import { Mover } from "src/mover/mover.entity";
-
-export type SafeMover = Omit<Mover, "password">;

--- a/src/mover/auth/auth.service.ts
+++ b/src/mover/auth/auth.service.ts
@@ -68,7 +68,6 @@ export class MoverAuthService {
       return {
         refreshToken,
         accessToken,
-        mover: existedMoverWithoutPw,
         type: "mover",
       };
     }
@@ -102,7 +101,6 @@ export class MoverAuthService {
     return {
       refreshToken,
       accessToken,
-      mover: newMoverWithoutPw,
       type: "mover",
     };
   }


### PR DESCRIPTION
## ✅ 변경 사항
- OAuth 로그인 시 응답에서 전체 customer/mover entity 객체 제거
- 각 OAuth 서비스에서 반환하는 DTO에서 불필요한 user 정보 제거
- Swagger example 정리
- 프로필 정보는 별도 조회 API로 충분히 커버 가능

## 🎯 목적
- Entity 객체가 직렬화 중 순환 참조 또는 과도한 메모리 사용 유발
- Render Free Tier(512MB)에서 메모리 초과로 서버 중단되는 문제 해결
- 응답 용량 및 보안 측면에서도 개선 효과


