### PR TITLE
fix: OAuth 가입 시 프로필 이미지 없이 가입하도록 수정

### DIFF
--- a/src/customer/auth/auth.service.ts
+++ b/src/customer/auth/auth.service.ts
@@ -76,7 +76,6 @@ export class CustomerAuthService {
     const newCustomerObject = this.customerRepository.create({
       username: oAuthLoginRequestDto.name,
       email: oAuthLoginRequestDto.email,
-      profileImage: oAuthLoginRequestDto.photo,
       phoneNumber: "000-0000-0000",
       provider: oAuthLoginRequestDto.provider,
     });

--- a/src/mover/auth/auth.service.ts
+++ b/src/mover/auth/auth.service.ts
@@ -77,7 +77,6 @@ export class MoverAuthService {
     const newMoverObject = this.moverRepository.create({
       username: oAuthLoginRequestDto.name,
       email: oAuthLoginRequestDto.email,
-      profileImage: oAuthLoginRequestDto.photo,
       phoneNumber: "000-0000-0000",
       provider: oAuthLoginRequestDto.provider,
     });


### PR DESCRIPTION
## 🌟 작업 내용 요약(500자 이내)

- OAuth 가입 시 프로필 이미지 없이 가입하도록 수정

## 📷 스크린샷

![스크린샷 2025-06-26 120007](https://github.com/user-attachments/assets/f9e3904c-c8d1-46de-807a-3444cb104971)

기존에는 OAuth에서 가져온 profile 이미지를 가입 때 등록되게 하려고 했으나 프로필 이미지 없이 가입하는게 나을 것 같아서 수정했습니다.

일단 회의 후에 PR 머지 여부 정해야할 것 같습니다.